### PR TITLE
added workaround for JJM 14149

### DIFF
--- a/lib/puppet/provider/domain_name/eos.rb
+++ b/lib/puppet/provider/domain_name/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:domain_name).provide(:eos) do
 

--- a/lib/puppet/provider/l2_interface/eos.rb
+++ b/lib/puppet/provider/l2_interface/eos.rb
@@ -1,7 +1,15 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
+
 Puppet::Type.type(:l2_interface).provide(:eos) do
 
   # Create methods that set the @property_hash for the #flush method

--- a/lib/puppet/provider/name_server/eos.rb
+++ b/lib/puppet/provider/name_server/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:name_server).provide(:eos) do
 

--- a/lib/puppet/provider/network_dns/eos.rb
+++ b/lib/puppet/provider/network_dns/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:network_dns).provide(:eos) do
 

--- a/lib/puppet/provider/network_interface/eos.rb
+++ b/lib/puppet/provider/network_interface/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:network_interface).provide(:eos) do
 

--- a/lib/puppet/provider/network_snmp/eos.rb
+++ b/lib/puppet/provider/network_snmp/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:network_snmp).provide(:eos) do
 

--- a/lib/puppet/provider/network_trunk/eos.rb
+++ b/lib/puppet/provider/network_trunk/eos.rb
@@ -2,7 +2,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:network_trunk).provide(:eos) do
 

--- a/lib/puppet/provider/network_vlan/eos.rb
+++ b/lib/puppet/provider/network_vlan/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:network_vlan).provide(:eos) do
 

--- a/lib/puppet/provider/ntp_config/eos.rb
+++ b/lib/puppet/provider/ntp_config/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:ntp_config).provide(:eos) do
 

--- a/lib/puppet/provider/ntp_server/eos.rb
+++ b/lib/puppet/provider/ntp_server/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:ntp_server).provide(:eos) do
 

--- a/lib/puppet/provider/port_channel/eos.rb
+++ b/lib/puppet/provider/port_channel/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:port_channel).provide(:eos) do
 

--- a/lib/puppet/provider/radius/eos.rb
+++ b/lib/puppet/provider/radius/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/eos/provider'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:radius).provide(:eos) do
 

--- a/lib/puppet/provider/radius_global/eos.rb
+++ b/lib/puppet/provider/radius_global/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:radius_global).provide(:eos) do
 

--- a/lib/puppet/provider/radius_server/eos.rb
+++ b/lib/puppet/provider/radius_server/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:radius_server).provide(:eos) do
 

--- a/lib/puppet/provider/radius_server_group/eos.rb
+++ b/lib/puppet/provider/radius_server_group/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:radius_server_group).provide(:eos) do
 

--- a/lib/puppet/provider/search_domain/eos.rb
+++ b/lib/puppet/provider/search_domain/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:search_domain).provide(:eos) do
 

--- a/lib/puppet/provider/snmp_community/eos.rb
+++ b/lib/puppet/provider/snmp_community/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:snmp_community).provide(:eos) do
 

--- a/lib/puppet/provider/snmp_notification/eos.rb
+++ b/lib/puppet/provider/snmp_notification/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:snmp_notification).provide(:eos) do
 

--- a/lib/puppet/provider/snmp_notification_receiver/eos.rb
+++ b/lib/puppet/provider/snmp_notification_receiver/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:snmp_notification_receiver).provide(:eos) do
 

--- a/lib/puppet/provider/snmp_user/eos.rb
+++ b/lib/puppet/provider/snmp_user/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:snmp_user).provide(:eos) do
 

--- a/lib/puppet/provider/syslog_server/eos.rb
+++ b/lib/puppet/provider/syslog_server/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:syslog_server).provide(:eos) do
 

--- a/lib/puppet/provider/syslog_settings/eos.rb
+++ b/lib/puppet/provider/syslog_settings/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:syslog_settings).provide(:eos) do
 

--- a/lib/puppet/provider/tacacs/eos.rb
+++ b/lib/puppet/provider/tacacs/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/eos/provider'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:tacacs).provide(:eos) do
 

--- a/lib/puppet/provider/tacacs_global/eos.rb
+++ b/lib/puppet/provider/tacacs_global/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:tacacs_global).provide(:eos) do
 

--- a/lib/puppet/provider/tacacs_server/eos.rb
+++ b/lib/puppet/provider/tacacs_server/eos.rb
@@ -1,8 +1,14 @@
-
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:tacacs_server).provide(:eos) do
 

--- a/lib/puppet/provider/tacacs_server_group/eos.rb
+++ b/lib/puppet/provider/tacacs_server_group/eos.rb
@@ -1,7 +1,14 @@
 # encoding: utf-8
 
 require 'puppet/type'
-require 'puppet_x/net_dev/eos_api'
+
+begin
+  require "puppet_x/net_dev/eos_api"
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
+end
 
 Puppet::Type.type(:tacacs_server_group).provide(:eos) do
 


### PR DESCRIPTION
Configuring:

```
  network_interface { 'Ethernet20':
    description => 'PUPPET_TEST',
    duplex      => 'auto',
    enable      => 'true',
    speed       => 'auto',
  }
```

The issue presented itself when running `bundle exec rake diffspec`:

```
 Could not autoload puppet/type/network_interface: Could not autoload puppet/provider/network_interface/eos: cannot load such file -- puppet_x/net_dev/eos_api on node ARISTA01
```

Had to make the following change in `modules/netdev_stdlib_eos/lib/puppet/provider/network_interface/eos.rb` for it to work:

```
require 'puppet/type'
#require 'puppet_x/net_dev/eos_api'

begin
  require "puppet_x/net_dev/eos_api"
rescue LoadError => detail
  require 'pathname' # JJM WORK_AROUND #14073
  module_base = Pathname.new(__FILE__).dirname
  require module_base + "../../../" + "puppet_x/net_dev/eos_api"
end
```

I also added the following line to `.gemspec`:

```
    gem.add_dependency 'rbeapi', '~> 0.1', '>= 0.1.0'
```

See also: https://projects.puppetlabs.com/issues/14149

The idea came from [puppetlabs/puppetlabs-registry](https://github.com/puppetlabs/puppetlabs-registry/blob/master/lib/puppet/provider/registry_key/registry.rb)
